### PR TITLE
git_repo_init.sh: rework and add branch/tag selection dialogs

### DIFF
--- a/git_repo_init.sh
+++ b/git_repo_init.sh
@@ -1,23 +1,70 @@
 #!/bin/sh
 
-if [ ! -e ".git/config" ]
+SVN_SERVER=svn://scribus.net
+
+# check whether whiptail or dialog is installed
+read dialog <<< "$(which whiptail dialog 2> /dev/null)"
+
+# exit if none found
+[[ "$dialog" ]] || {
+  echo 'neither whiptail nor dialog found' >&2
+  exit 1
+}
+
+function show_list {
+    title=$1
+    shift
+    checklist=""
+    n=1
+    for branch in $@
+    do
+	checklist="$checklist ${branch%/} $n"
+	git config --get svn-remote.svn.fetch "(branches|tags)/${branch%/}" 2> /dev/null
+	if [ $? -eq 0 ]
+	then
+	    checklist="$checklist on"
+	else
+	    checklist="$checklist off"
+	fi
+	n=$[n+1]
+    done
+
+    exec 3>&1
+    choices=$($dialog --checklist "$title" 0 0 0 $checklist 2>&1 1>&3)
+    exitcode=$?
+    exec 3>&-
+}
+
+svn_branches=$(svn ls $SVN_SERVER/branches 2> /dev/null)
+show_list "Select branches to import" $svn_branches
+branch_choices=$choices
+if [ $exitcode -ne 0 ]
 then
-    echo "$0 must be run at the root of an empty git repository."
     exit 1
 fi
 
-git svn status 2> /dev/null
-if [ $(grep -c "svn-remote" .git/config) -eq 0 ]
+svn_tags=$(svn ls $SVN_SERVER/tags 2> /dev/null)
+show_list "Select tags to import" $svn_tags
+tag_choices=$choices
+if [ $exitcode -ne 0 ]
 then
-    cat >> .git/config <<EOF
-[svn-remote "svn"]
-        url = svn://scribus.net
-        fetch = trunk/Scribus:refs/heads/master
-	branches = branches/*/Scribus:refs/heads/*
-	tags = tags/*/Scribus:refs/remotes/svn/tags/*
-[svn]
-        authorsfile = $(dirname $0)/svn_authors.txt
-EOF
-else
-    echo "Repository already contains a git svn configuration. Not changing anything."
+    exit 1
 fi
+
+#create backup of .git/config
+cp .git/config .git/config.bak
+
+git config svn.authorsfile $(dirname $0)/svn_authors.txt
+git config svn-remote.svn.url $SVN_SERVER
+git config --unset-all svn-remote.svn.fetch
+git config svn-remote.svn.fetch trunk/Scribus:refs/heads/master
+
+for choice in $branch_choices
+do
+    git config --add svn-remote.svn.fetch "branches/$choice/Scribus:refs/heads/$choice"
+done
+
+for choice in $tag_choices
+do
+    git config --add svn-remote.svn.fetch "tags/$choice/Scribus:refs/remotes/svn/tags/$choice"
+done


### PR DESCRIPTION
Running the script now queries the user which branches and tags
should be synchronized from SVN. Script can now be run again and
allows changing the settings.

Depends on either dialog or whiptail.
